### PR TITLE
Fixed mono_tum crash at save output

### DIFF
--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 {
     if(argc != 5) // Changed this to 5 to accept the output path otherwise will crash at line 141
     {
-        cerr << endl << "Usage: ./mono_tum path_to_vocabulary path_to_settings path_to_sequence path_to_sequence path_to_trajectory_result_file(*.txt should work)" << endl;
+        cerr << endl << "Usage: ./mono_tum path_to_vocabulary path_to_settings path_to_sequence path_to_trajectory_result_file(*.txt should work)" << endl;
         return 1;
     }
 

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -36,7 +36,7 @@ void LoadImages(const string &strFile, vector<string> &vstrImageFilenames,
 
 int main(int argc, char **argv)
 {
-    if(argc != 4)
+    if(argc != 5) // Changed this to 5 to accept the output path otherwise will crash at line 141
     {
         cerr << endl << "Usage: ./mono_tum path_to_vocabulary path_to_settings path_to_sequence path_to_sequence path_to_trajectory_result_file(*.txt should work)" << endl;
         return 1;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
+# Some Results:
+Standard Run Kitti07:
+
+![kitti07_map](https://user-images.githubusercontent.com/33178694/125855386-d0635d0f-f659-4ba3-a895-acacb686ac67.png)
+
+Standard run Tum:
+
+![tum_map](https://user-images.githubusercontent.com/33178694/125855444-3f7c6d4b-9fd8-4ace-93a4-39997fd5816b.png)
+
+Kitti07 without removing outliers:
+
+![kittie07_outlier2_map](https://user-images.githubusercontent.com/33178694/125855651-7814b482-8bd2-43db-8a57-9fe4b038cb76.png)
+
+Tum without removing outliers:
+
+![tum_outlier_map](https://user-images.githubusercontent.com/33178694/125855684-81657f87-077f-4e58-8557-f97a8484ea69.png)
+
+Kitti07 with loop closure turned off:
+
+![kitti07_noloop_map](https://user-images.githubusercontent.com/33178694/125855777-5139f058-f3b7-49d7-94e4-e64536cf1f31.png)
+
+Tum without removing outliers and with loop closure turned off:
+
+![tum_outlierLoopC_map](https://user-images.githubusercontent.com/33178694/125855857-f8157b8b-a886-4d37-98fa-b473384e520c.png)
+
+
+# @ Original README
 # ORB-SLAM2 - For Mac
 This version is provided for consistency with https://github.com/JingwenWang95/ORB_SLAM2.
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,3 @@
-# Some Results:
-Standard Run Kitti07:
-
-![kitti07_map](https://user-images.githubusercontent.com/33178694/125855386-d0635d0f-f659-4ba3-a895-acacb686ac67.png)
-
-Standard run Tum:
-
-![tum_map](https://user-images.githubusercontent.com/33178694/125855444-3f7c6d4b-9fd8-4ace-93a4-39997fd5816b.png)
-
-Kitti07 without removing outliers:
-
-![kittie07_outlier2_map](https://user-images.githubusercontent.com/33178694/125855651-7814b482-8bd2-43db-8a57-9fe4b038cb76.png)
-
-Tum without removing outliers:
-
-![tum_outlier_map](https://user-images.githubusercontent.com/33178694/125855684-81657f87-077f-4e58-8557-f97a8484ea69.png)
-
-Kitti07 with loop closure turned off:
-
-![kitti07_noloop_map](https://user-images.githubusercontent.com/33178694/125855777-5139f058-f3b7-49d7-94e4-e64536cf1f31.png)
-
-Tum without removing outliers and with loop closure turned off:
-
-![tum_outlierLoopC_map](https://user-images.githubusercontent.com/33178694/125855857-f8157b8b-a886-4d37-98fa-b473384e520c.png)
-
-
-# @ Original README
 # ORB-SLAM2 - For Mac
 This version is provided for consistency with https://github.com/JingwenWang95/ORB_SLAM2.
 


### PR DESCRIPTION
Changed the number of arguments accepted by mono_tum to accept the 4th output argument mentioned in line 141 but not available.